### PR TITLE
ddtp.debian.net is now ddtp2.debian.net

### DIFF
--- a/packages/ddtss/canned-strings.user.js
+++ b/packages/ddtss/canned-strings.user.js
@@ -2,8 +2,8 @@
 // @name Canned strings for DDTSS
 // @description Add prepared phrases for comments
 // @version 0.4
-// @match https://ddtp.debian.net/ddtss/index.cgi/*/forreview/*
-// @match https://ddtp.debian.net/ddtss/index.cgi/*/translate/*
+// @match https://ddtp2.debian.net/ddtss/index.cgi/*/forreview/*
+// @match https://ddtp2.debian.net/ddtss/index.cgi/*/translate/*
 // @grant none
 // ==/UserScript==
 // Daniele Forsi 07/01/2016

--- a/packages/ddtss/ddtss-lite.user.js
+++ b/packages/ddtss/ddtss-lite.user.js
@@ -2,8 +2,8 @@
 // @name DDTSS Helper
 // @description Add stuff to DDTSS pages
 // @version 0.6
-// @match https://ddtp.debian.net/ddtss/index.cgi/*/forreview/*
-// @match https://ddtp.debian.net/ddtss/index.cgi/*/translate/*
+// @match https://ddtp2.debian.net/ddtss/index.cgi/*/forreview/*
+// @match https://ddtp2.debian.net/ddtss/index.cgi/*/translate/*
 // @grant none
 // ==/UserScript==
 // Daniele Forsi


### PR DESCRIPTION
Hello,

Due to DNS issues, the DDTSS address recently changed from ddtp.debian.net to ddtp2.debian.net.
This pull request updates the addresses matched in the GreaseMonkey scripts.

Cheers,
Thomas
